### PR TITLE
A new funny pull request :)

### DIFF
--- a/kerning.js
+++ b/kerning.js
@@ -424,9 +424,9 @@
          * browsers and operating systems. We need CSS flags to allow for that.
          */
         var self = this
-          , basic_properties = ['background-color', 'color', 'transform', 'display'] // properties with a single unit
-          , prefixed_properties = ['border-radius', 'transform'] // 
-          , shortand_properties = ['background', 'box-shadow', 'border-radius', 'text-shadow']
+          , basic_properties = ['background-color', 'color', 'transform', 'display', 'font-family', 'opacity'] // properties with a single unit
+          , prefixed_properties = ['border-radius', 'transform', 'box-shadow'] // 
+          , shortand_properties = ['background', 'box-shadow', 'border-radius', 'text-shadow', 'padding', 'margin']
           , nav = navigator.platform
           , browserPrefix = [
               'webkitTransform' in document.documentElement.style && 'webkit'


### PR DESCRIPTION
Hello,

I've just added the possibility to use shorthand properties. However you need to put brackets for each letter or each word you want to target
Example : -word-text-shadow: (1px 1px 0px rgba(0,0,0,0.5), 2px 2px 0px rgba(0,0,0,0.5)) _ (rgba(150,150,150,0.5) 1px 1px 0px, 2px 2px 0px yellow);

I've also simplified the access of some basic properties (transform, color, background-color). You have a simple array that list these properties. You will able to add others properties easily ;)

Hope you enjoy...
