### PR TITLE
remove use of $.browser

### DIFF
--- a/kerning.js
+++ b/kerning.js
@@ -420,7 +420,7 @@
           , nav = navigator.platform
           , browserPrefix = [
               'webkitTransform' in document.documentElement.style && 'webkit'
-            , $.browser.msie && 'ms'
+			, navigator.userAgent.indexOf("MSIE") > -1 && 'ms'
             , "MozTransform" in document.documentElement.style && 'moz'
             , window.opera && 'o'
             ].reduce(function(pv, cv) { return pv + (cv || ''); })


### PR DESCRIPTION
$.browser is deprecated in newer versions of jQuery.  To be used with these versions it needs to use alternative means of browser detection.  Here I am querying the userAgent string for 'MSIE', since IE was the only browser using this method.
