### PR TITLE
Fix regex that prevented the use of single quote in letter-pairs

### DIFF
--- a/kerning.js
+++ b/kerning.js
@@ -445,7 +445,7 @@
                   , isTransform = pairString.match(/translate|rotate|skew|perspective/i)
 
                     // matches and splits the pairing rules
-                  , pairs = $.trim(usingPairs[2].replace(/,\s+?'/g, ",'").replace(/:\s+?(\d)/g, ':$1')).split(isTransform ? '),' : ',')
+                  , pairs = $.trim(usingPairs[2].replace(/,\s+?['"]/g, ",'").replace(/:\s+?(\d)/g, ':$1')).split(isTransform ? '),' : ',')
                   
                   , pairInfo, pairKeys, pairDown
                   , pairElements = [];


### PR DESCRIPTION
This will still need a version bump and js minified. The minified version was not in sync and I'm not sure which minifier was originally used.